### PR TITLE
Fix getName regex for InternetExplorer 11.

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ function getName (value) {
 //  if (value.constructor.name !== undefined) return fn.name
 
   // why not constructor.name: https://kangax.github.io/compat-table/es6/#function_name_property
-  var match = value.constructor.toString().match(/function (.*?)\(/)
+  var match = value.constructor.toString().match(/function (.*?)\s*\(/)
   return match ? match[1] : null
 }
 


### PR DESCRIPTION
I am having a problem with bitcoinjs and IE11. 

Actually if you run this code in chrome and IE11 you will find different results:

function MyType () {};
var x = new MyType();
x.constructor.toString().match(/function (.*?)(/)[1]

=> The result in chrome is "MyType" but in IE is "MyType "

Returning a bad type name is producing a type check error when calling Transaction.prototype.addOutput with an object of type Script in IE11.

I think that running minified code solves the problem. In bitcoinJS codestyle you always define functions with blank spaces after the name. In any case, changing the regular expression to ignore blank spaces after the name will solve the problem.
