### PR TITLE
fix io.js Buffer property differences

### DIFF
--- a/test/fixtures.json
+++ b/test/fixtures.json
@@ -5873,7 +5873,7 @@
       "valueId": "function"
     },
     {
-      "exception": "Unexpected property \"length\"",
+      "exception": "Unexpected property \"(asciiSlice|length)\"",
       "strict": true,
       "typeId": "?{ a: ?Number }",
       "valueId": "buffer"
@@ -6186,7 +6186,7 @@
       "valueId": "function"
     },
     {
-      "exception": "Unexpected property \"length\"",
+      "exception": "Unexpected property \"(asciiSlice|length)\"",
       "strict": true,
       "typeId": "{ a: Number|Null }",
       "valueId": "buffer"
@@ -6496,7 +6496,7 @@
       "valueId": "function"
     },
     {
-      "exception": "Unexpected property \"length\"",
+      "exception": "Unexpected property \"(asciiSlice|length)\"",
       "strict": true,
       "typeId": "{ a: ?{ b: Number } }",
       "valueId": "buffer"
@@ -6636,7 +6636,7 @@
       "valueId": "function"
     },
     {
-      "exception": "Unexpected property \"length\"",
+      "exception": "Unexpected property \"(asciiSlice|length)\"",
       "strict": true,
       "typeId": "{ a: ?{ b: ?{ c: Number } } }",
       "valueId": "buffer"
@@ -6970,7 +6970,7 @@
       "valueId": "function"
     },
     {
-      "exception": "Unexpected property \"length\"",
+      "exception": "Unexpected property \"(asciiSlice|length)\"",
       "strict": true,
       "typeId": "{ a: ?Tt }",
       "valueId": "buffer"

--- a/test/index.js
+++ b/test/index.js
@@ -27,7 +27,7 @@ describe('typeforce', function () {
     var value = VALUES[f.valueId] || f.value
     var typeDescription = f.typeId || JSON.stringify(type)
     var valueDescription = JSON.stringify(value)
-    var exception = f.exception.replace(/([.*+?^=!:${}()|\[\]\/\\])/g, '\\$&')
+    var exception = f.exception.replace(/([.*+?^=!:${}\[\]\/\\])/g, '\\$&')
 
     it('throws "' + exception + '" for type ' + typeDescription + ' with value of ' + valueDescription, function () {
       assert.throws(function () {


### PR DESCRIPTION
Travis CI was failing with io.js due to io.js `Buffer` properties being different to node,  and breaking the deterministic tests.
