### PR TITLE
Cleanup / Maintain stack trace on TfPropertyTypeError's

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,11 +19,8 @@ function TfTypeError (type, value) {
 inherits(TfTypeError, Error)
 Object.defineProperty(TfTypeError, 'stack', { get: function () { return this.tfError.stack } })
 
-function TfPropertyTypeError (type, property, value, expected, error) {
-  expected = expected === undefined ? true : expected
-
+function TfPropertyTypeError (type, property, value, error) {
   this.tfError = error || Error.call(this)
-  this.tfExpected = expected
   this.tfProperty = property
   this.tfType = type
   this.tfValue = value
@@ -32,7 +29,7 @@ function TfPropertyTypeError (type, property, value, expected, error) {
   Object.defineProperty(this, 'message', {
     get: function () {
       if (message) return message
-      if (expected) {
+      if (type) {
         message = tfPropertyErrorString(type, property, value)
       } else {
         message = 'Unexpected property "' + property + '"'
@@ -47,7 +44,7 @@ inherits(TfPropertyTypeError, Error)
 Object.defineProperty(TfPropertyTypeError, 'stack', { get: function () { return this.tfError.stack } })
 
 TfPropertyTypeError.prototype.asChildOf = function (property) {
-  return new TfPropertyTypeError(this.tfType, property + '.' + this.tfProperty, this.tfValue, this.tfExpected, this.tfError)
+  return new TfPropertyTypeError(this.tfType, property + '.' + this.tfProperty, this.tfValue, this.tfError)
 }
 
 function getFunctionName (fn) {
@@ -156,7 +153,7 @@ var otherTypes = {
         for (propertyName in value) {
           if (type[propertyName]) continue
 
-          throw new TfPropertyTypeError(undefined, propertyName, undefined, false)
+          throw new TfPropertyTypeError(undefined, propertyName)
         }
       }
 

--- a/index.js
+++ b/index.js
@@ -143,7 +143,7 @@ var otherTypes = {
         if (e instanceof TfPropertyTypeError) {
           throw e.asChildOf(propertyName)
         } else if (e instanceof TfTypeError) {
-          throw new TfPropertyTypeError(e.tfType, propertyName, e.tfValue)
+          throw new TfPropertyTypeError(e.tfType, propertyName, e.tfValue, e.tfError)
         }
 
         throw e

--- a/package.json
+++ b/package.json
@@ -23,10 +23,10 @@
   "scripts": {
     "coverage": "mocha --require blanket -R travis-cov",
     "coverage-local": "mocha --require blanket -R html-cov",
-    "generate-test": "mocha test/__generate.js",
+    "generate-test": "mocha scripts/__generate.js",
     "standard": "standard",
     "test": "npm run standard && npm run unit",
-    "unit": "mocha test/index.js"
+    "unit": "mocha"
   },
   "config": {
     "blanket": {


### PR DESCRIPTION
Currently, the stack trace is equivalent to the throw site of `TfPropertyTypeError`,  when really it threw deeper than that.
This fixes that by keeping the original `TfTypeError.tfError` instead of recreating it.

Other cleanup and fixes are also included.
