### PR TITLE
allow creation of `TfTypeError` with 1st and only argument the message.

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,18 +2,23 @@ var inherits = require('inherits')
 
 function TfTypeError (type, value) {
   this.tfError = Error.call(this)
-  this.tfType = type
-  this.tfValue = value
 
-  var message
-  Object.defineProperty(this, 'message', {
-    get: function () {
-      if (message) return message
-      message = tfErrorString(type, value)
+  if (arguments.length === 1 && typeof type === 'string') {
+    this.message = type
+  } else {
+    this.tfType = type
+    this.tfValue = value
 
-      return message
-    }
-  })
+    var message
+    Object.defineProperty(this, 'message', {
+      get: function () {
+        if (message) return message
+        message = tfErrorString(type, value)
+
+        return message
+      }
+    })
+  }
 }
 
 inherits(TfTypeError, Error)

--- a/test/index.js
+++ b/test/index.js
@@ -42,4 +42,31 @@ describe('typeforce', function () {
       }, new RegExp(exception))
     })
   })
+
+  describe('custom errors', function () {
+    var err = new typeforce.TfTypeError('custom error')
+    var everFailingType = function () { throw new typeforce.TfTypeError('custom error') }
+
+    it('has the custom message', function () {
+      assert(err.message === 'custom error')
+    })
+
+    it('is instance of TfTypeError', function () {
+      assert(err instanceof typeforce.TfTypeError)
+    })
+
+    it('assert.throws knows how to handle it', function () {
+      assert.throws(function () {
+        typeforce(everFailingType, 'value')
+      }, new RegExp('custom error'))
+    })
+
+    it('is caught in oneOf', function () {
+      assert(!typeforce.oneOf(everFailingType)('value'))
+    })
+
+    it('does not break oneOf', function () {
+      assert(!typeforce.oneOf(everFailingType, typeforce.string)('value'))
+    })
+  })
 })


### PR DESCRIPTION
desired for custom error throwing (see discussion https://github.com/blocktrail/bitcoinjs-lib/pull/1)
