### PR TITLE
Optional error information instead of throwing (by default)

### DIFF
--- a/extra.js
+++ b/extra.js
@@ -13,10 +13,12 @@ function _LengthN (type, length) {
   var name = type.toJSON()
 
   function Length (value) {
+    delete Length.TfTypeError
     if (!type(value)) return false
     if (value.length === length) return true
 
-    throw ERRORS.tfCustomError(name + '(Length: ' + length + ')', name + '(Length: ' + value.length + ')')
+    Length.TfTypeError = ERRORS.tfCustomError(name + '(Length: ' + length + ')', name + '(Length: ' + value.length + ')')
+    return false
   }
   Length.toJSON = function () { return name }
 


### PR DESCRIPTION
From https://github.com/dcousens/typeforce/issues/42

Type functions should simply **always return false** on failure rather than **returning false OR throwing**.

The problem is, without extra information,  the error messages would suck,  so return false AND add the extra information, could give the best of both.