### PR TITLE
Add a mangling canary

### DIFF
--- a/index.js
+++ b/index.js
@@ -137,7 +137,8 @@ var TYPES = {
 
   quacksLike: function quacksLike (type) {
     function _quacksLike (value) {
-      return type === getValueTypeName(value)
+      return getValueTypeName(new ManglingCanary()) === 'ManglingCanary' &&
+             type === getValueTypeName(value)
     }
     _quacksLike.toJSON = function () { return type }
 
@@ -174,6 +175,8 @@ var TYPES = {
     return _value
   }
 }
+
+function ManglingCanary () {}; // To detect mangling of the source code
 
 function compile (type) {
   if (NATIVE.String(type)) {


### PR DESCRIPTION
Ideally we wouldn't use mangling, but sometimes it's not possible.

This detects mangling and turns off `quacksLike` checks when source is mangled (see #28)