### PR TITLE
Check prototype instead of name for custom constructors

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,15 +106,15 @@ function Foo () {
   this.x = 2
 }
 
-typeforce(typeforce.quacksLike('Foo'), new Foo())
+typeforce(typeforce.constructorName('Foo'), new Foo())
 // OK!
 
 // Note, any Foo will do
-typeforce(typeforce.quacksLike('Foo'), new (function Foo() {}))
+typeforce(typeforce.constructorName('Foo'), new (function Foo() {}))
 // OK!
 ```
 
-**WARNING**: Be very wary of using the `quacksLike` type, as it relies on the `Foo.name` property.
+**WARNING**: Be very wary of using the `constructorName` type, as it relies on the `Foo.name` property.
 If that property is mangled by a transpiler,  such as `uglifyjs`,  you will have a bad time.
 
 ## LICENSE [ISC](LICENSE)

--- a/README.md
+++ b/README.md
@@ -106,15 +106,13 @@ function Foo () {
   this.x = 2
 }
 
-typeforce(typeforce.constructorName('Foo'), new Foo())
+typeforce(typeforce.quacksLike(Foo), new Foo())
 // OK!
 
 // Note, any Foo will do
-typeforce(typeforce.constructorName('Foo'), new (function Foo() {}))
+typeforce(typeforce.quacksLike(Foo), Object.create(Foo.prototype))
 // OK!
 ```
 
-**WARNING**: Be very wary of using the `constructorName` type, as it relies on the `Foo.name` property.
-If that property is mangled by a transpiler,  such as `uglifyjs`,  you will have a bad time.
 
 ## LICENSE [ISC](LICENSE)

--- a/index.js
+++ b/index.js
@@ -135,6 +135,16 @@ var TYPES = {
     return _oneOf
   },
 
+  quacksLike: function quacksLike (Type) {
+    function _quacksLike (value) {
+      return Type.prototype.isPrototypeOf(value)
+    }
+
+    _quacksLike.toJSON = function () { return Type.name }
+
+    return _quacksLike
+  },
+
   constructorName: function constructorName (type) {
     function _constructorName (value) {
       return type === getValueTypeName(value)

--- a/index.js
+++ b/index.js
@@ -135,13 +135,13 @@ var TYPES = {
     return _oneOf
   },
 
-  quacksLike: function quacksLike (type) {
-    function _quacksLike (value) {
+  constructorName: function constructorName (type) {
+    function _constructorName (value) {
       return type === getValueTypeName(value)
     }
-    _quacksLike.toJSON = function () { return type }
+    _constructorName.toJSON = function () { return type }
 
-    return _quacksLike
+    return _constructorName
   },
 
   tuple: function tuple () {
@@ -179,7 +179,7 @@ function compile (type) {
   if (NATIVE.String(type)) {
     if (type[0] === '?') return TYPES.maybe(type.slice(1))
 
-    return NATIVE[type] || TYPES.quacksLike(type)
+    return NATIVE[type] || TYPES.constructorName(type)
   } else if (type && NATIVE.Object(type)) {
     if (NATIVE.Array(type)) return TYPES.arrayOf(type[0])
 

--- a/test/fixtures.json
+++ b/test/fixtures.json
@@ -1520,6 +1520,10 @@
       "valueId": "customType"
     },
     {
+      "typeId": "CustomClass",
+      "valueId": "customClass"
+    },
+    {
       "typeId": "{ String }",
       "value": []
     },
@@ -13102,6 +13106,254 @@
       "valueId": "String4"
     },
     {
+      "exception": "Expected Waterfowl, got String \"\"",
+      "typeId": "CustomClass",
+      "value": ""
+    },
+    {
+      "exception": "Expected Waterfowl, got String \"foobar\"",
+      "typeId": "CustomClass",
+      "value": "foobar"
+    },
+    {
+      "exception": "Expected Waterfowl, got Number 0",
+      "typeId": "CustomClass",
+      "value": 0
+    },
+    {
+      "exception": "Expected Waterfowl, got Number 1",
+      "typeId": "CustomClass",
+      "value": 1
+    },
+    {
+      "exception": "Expected Waterfowl, got Array",
+      "typeId": "CustomClass",
+      "value": []
+    },
+    {
+      "exception": "Expected Waterfowl, got Array",
+      "typeId": "CustomClass",
+      "value": [
+        0
+      ]
+    },
+    {
+      "exception": "Expected Waterfowl, got Array",
+      "typeId": "CustomClass",
+      "value": [
+        "foobar"
+      ]
+    },
+    {
+      "exception": "Expected Waterfowl, got Array",
+      "typeId": "CustomClass",
+      "value": [
+        {
+          "a": 0
+        }
+      ]
+    },
+    {
+      "exception": "Expected Waterfowl, got Array",
+      "typeId": "CustomClass",
+      "value": [
+        null
+      ]
+    },
+    {
+      "exception": "Expected Waterfowl, got Boolean false",
+      "typeId": "CustomClass",
+      "value": false
+    },
+    {
+      "exception": "Expected Waterfowl, got Boolean true",
+      "typeId": "CustomClass",
+      "value": true
+    },
+    {
+      "exception": "Expected Waterfowl, got undefined",
+      "typeId": "CustomClass"
+    },
+    {
+      "exception": "Expected Waterfowl, got null",
+      "typeId": "CustomClass",
+      "value": null
+    },
+    {
+      "exception": "Expected Waterfowl, got Object",
+      "typeId": "CustomClass",
+      "value": {}
+    },
+    {
+      "exception": "Expected Waterfowl, got Object",
+      "typeId": "CustomClass",
+      "value": {
+        "a": null
+      }
+    },
+    {
+      "exception": "Expected Waterfowl, got Object",
+      "typeId": "CustomClass",
+      "value": {
+        "a": 0
+      }
+    },
+    {
+      "exception": "Expected Waterfowl, got Object",
+      "typeId": "CustomClass",
+      "value": {
+        "a": 0,
+        "b": 0
+      }
+    },
+    {
+      "exception": "Expected Waterfowl, got Object",
+      "typeId": "CustomClass",
+      "value": {
+        "b": 0
+      }
+    },
+    {
+      "exception": "Expected Waterfowl, got Object",
+      "typeId": "CustomClass",
+      "value": {
+        "a": {
+          "b": 0
+        }
+      }
+    },
+    {
+      "exception": "Expected Waterfowl, got Object",
+      "typeId": "CustomClass",
+      "value": {
+        "a": {
+          "b": null
+        }
+      }
+    },
+    {
+      "exception": "Expected Waterfowl, got Object",
+      "typeId": "CustomClass",
+      "value": {
+        "a": {
+          "b": {
+            "c": 0
+          }
+        }
+      }
+    },
+    {
+      "exception": "Expected Waterfowl, got Object",
+      "typeId": "CustomClass",
+      "value": {
+        "a": {
+          "b": {
+            "c": null
+          }
+        }
+      }
+    },
+    {
+      "exception": "Expected Waterfowl, got Object",
+      "typeId": "CustomClass",
+      "value": {
+        "a": {
+          "b": {
+            "c": 0,
+            "d": 0
+          }
+        }
+      }
+    },
+    {
+      "exception": "Expected Waterfowl, got Object",
+      "typeId": "CustomClass",
+      "value": {
+        "a": "foo",
+        "b": "bar"
+      }
+    },
+    {
+      "exception": "Expected Waterfowl, got Object",
+      "typeId": "CustomClass",
+      "value": {
+        "a": "foo",
+        "b": {
+          "c": "bar"
+        }
+      }
+    },
+    {
+      "exception": "Expected Waterfowl, got Function",
+      "typeId": "CustomClass",
+      "valueId": "function"
+    },
+    {
+      "exception": "Expected Waterfowl, got EmptyType",
+      "typeId": "CustomClass",
+      "valueId": "emptyType"
+    },
+    {
+      "exception": "Expected Waterfowl, got Object",
+      "typeId": "CustomClass",
+      "valueId": "{ a: undefined }"
+    },
+    {
+      "exception": "Expected Waterfowl, got Object",
+      "typeId": "CustomClass",
+      "valueId": "{ a: Buffer3 }"
+    },
+    {
+      "exception": "Expected Waterfowl, got Object",
+      "typeId": "CustomClass",
+      "valueId": "{ a: Buffer10 }"
+    },
+    {
+      "exception": "Expected Waterfowl, got Object",
+      "typeId": "CustomClass",
+      "valueId": "{ a: { b: Buffer3 } }"
+    },
+    {
+      "exception": "Expected Waterfowl, got Object",
+      "typeId": "CustomClass",
+      "valueId": "{ a: { b: Buffer10 } }"
+    },
+    {
+      "exception": "Expected Waterfowl, got Array",
+      "typeId": "CustomClass",
+      "valueId": "Array5"
+    },
+    {
+      "exception": "Expected Waterfowl, got Array",
+      "typeId": "CustomClass",
+      "valueId": "Array6"
+    },
+    {
+      "exception": "Expected Waterfowl, got Array",
+      "typeId": "CustomClass",
+      "valueId": "Array7"
+    },
+    {
+      "exception": "Expected Waterfowl, got Buffer",
+      "typeId": "CustomClass",
+      "valueId": "Buffer"
+    },
+    {
+      "exception": "Expected Waterfowl, got Buffer",
+      "typeId": "CustomClass",
+      "valueId": "Buffer3"
+    },
+    {
+      "exception": "Expected Waterfowl, got Buffer",
+      "typeId": "CustomClass",
+      "valueId": "Buffer10"
+    },
+    {
+      "exception": "Expected Waterfowl, got String \"boop\"",
+      "typeId": "CustomClass",
+      "valueId": "String4"
+    },
+    {
       "exception": "Expected \\{String\\}, got String \"\"",
       "typeId": "{ String }",
       "value": ""
@@ -21546,6 +21798,86 @@
     {
       "exception": "Expected CustomType, got Number 9007199254740994",
       "typeId": ">CustomType",
+      "value": 9007199254740994
+    },
+    {
+      "exception": "Expected Waterfowl, got String \"fff\"",
+      "typeId": "CustomClass",
+      "value": "fff"
+    },
+    {
+      "exception": "Expected Waterfowl, got String \"cafe1122deadbeef\"",
+      "typeId": "CustomClass",
+      "value": "cafe1122deadbeef"
+    },
+    {
+      "exception": "Expected Waterfowl, got String \"0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20\"",
+      "typeId": "CustomClass",
+      "value": "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20"
+    },
+    {
+      "exception": "Expected Waterfowl, got Number -1",
+      "typeId": "CustomClass",
+      "value": -1
+    },
+    {
+      "exception": "Expected Waterfowl, got Number 127",
+      "typeId": "CustomClass",
+      "value": 127
+    },
+    {
+      "exception": "Expected Waterfowl, got Number 128",
+      "typeId": "CustomClass",
+      "value": 128
+    },
+    {
+      "exception": "Expected Waterfowl, got Number 255",
+      "typeId": "CustomClass",
+      "value": 255
+    },
+    {
+      "exception": "Expected Waterfowl, got Number 256",
+      "typeId": "CustomClass",
+      "value": 256
+    },
+    {
+      "exception": "Expected Waterfowl, got Number -128",
+      "typeId": "CustomClass",
+      "value": -128
+    },
+    {
+      "exception": "Expected Waterfowl, got Number -129",
+      "typeId": "CustomClass",
+      "value": -129
+    },
+    {
+      "exception": "Expected Waterfowl, got Number 65534",
+      "typeId": "CustomClass",
+      "value": 65534
+    },
+    {
+      "exception": "Expected Waterfowl, got Number 65535",
+      "typeId": "CustomClass",
+      "value": 65535
+    },
+    {
+      "exception": "Expected Waterfowl, got Number 65536",
+      "typeId": "CustomClass",
+      "value": 65536
+    },
+    {
+      "exception": "Expected Waterfowl, got Number 4294967295",
+      "typeId": "CustomClass",
+      "value": 4294967295
+    },
+    {
+      "exception": "Expected Waterfowl, got Number 9007199254740991",
+      "typeId": "CustomClass",
+      "value": 9007199254740991
+    },
+    {
+      "exception": "Expected Waterfowl, got Number 9007199254740994",
+      "typeId": "CustomClass",
       "value": 9007199254740994
     },
     {

--- a/test/objects.js
+++ b/test/objects.js
@@ -1,0 +1,15 @@
+function Waterfowl () {}
+Waterfowl.prototype.speak = function () {
+  return 'quack'
+}
+Waterfowl.prototype.walk = function () {
+  return 'waddle'
+}
+
+function Duck () {}
+Duck.prototype = Object.create(Waterfowl.prototype)
+
+module.exports = {
+  Waterfowl: Waterfowl,
+  Duck: Duck
+}

--- a/test/types.js
+++ b/test/types.js
@@ -1,4 +1,5 @@
 var typeforce = require('../')
+var objects = require('./objects')
 
 function Unmatchable () { return false }
 function Letter (value) {
@@ -25,6 +26,7 @@ module.exports = {
   '{ a: ?Unmatchable }': { a: typeforce.maybe(Unmatchable) },
   '{ a: { b: Unmatchable } }': { a: { b: Unmatchable } },
   '>CustomType': typeforce.constructorName('CustomType'),
+  'CustomClass': typeforce.quacksLike(objects.Waterfowl),
   '{ String }': typeforce.map('String'),
   '{ String|Number }': typeforce.map(typeforce.oneOf('String', 'Number')),
   '{ String: Number }': typeforce.map('Number', 'String'),

--- a/test/types.js
+++ b/test/types.js
@@ -24,7 +24,7 @@ module.exports = {
   '?Unmatchable': typeforce.maybe(Unmatchable),
   '{ a: ?Unmatchable }': { a: typeforce.maybe(Unmatchable) },
   '{ a: { b: Unmatchable } }': { a: { b: Unmatchable } },
-  '>CustomType': typeforce.quacksLike('CustomType'),
+  '>CustomType': typeforce.constructorName('CustomType'),
   '{ String }': typeforce.map('String'),
   '{ String|Number }': typeforce.map(typeforce.oneOf('String', 'Number')),
   '{ String: Number }': typeforce.map('Number', 'String'),

--- a/test/values.js
+++ b/test/values.js
@@ -1,3 +1,5 @@
+var objects = require('./objects')
+
 var buffer3 = Buffer.from('ffffff', 'hex')
 var buffer10 = Buffer.from('ffffffffffffffffffff', 'hex')
 
@@ -5,6 +7,7 @@ module.exports = {
   'function': function () {},
   'emptyType': new function EmptyType () {}(),
   'customType': new function CustomType () { this.x = 2 }(),
+  'customClass': new objects.Duck(),
   '{ a: undefined }': { a: undefined },
   '{ a: Buffer3 }': { a: buffer3 },
   '{ a: Buffer10 }': { a: buffer10 },


### PR DESCRIPTION
This is a WIP pull request as a proposal to fix #12. It uses method 4 of [my proposal](https://github.com/dcousens/typeforce/issues/12#issuecomment-349797207), so it may not fully address the expected scope of the issue.