### PR TITLE
add async/nothrow variants of typeforce, with docs and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,31 @@ typeforce(typeforce.quacksLike('Foo'), new (function Foo() {}))
 // OK!
 ```
 
+**Pro**tips (no throw)
+``` javascript
+var typeforce = require('typeforce/nothrow')
+var value = 'foobar'
+
+if (typeforce(typeforce.Number, value)) {
+	// didn't throw!
+	console.log(`${value} is a number`) // never happens
+} else {
+	console.log(`Oops, ${typeforce.error.message}`)
+	// prints 'Oops, Expected Number, got String foobar'
+}
+```
+
+**Pro**tips (async)
+```
+var typeforce = require('typeforce/async')
+
+typeforce(typeforce.Number, value, function (err) {
+	if (err) return console.log(`Oops, ${typeforce.error.message}`)
+
+	console.log(`${value} is a number`) // never happens
+})
+```
+
 **WARNING**: Be very wary of using the `quacksLike` type, as it relies on the `Foo.name` property.
 If that property is mangled by a transpiler,  such as `uglifyjs`,  you will have a bad time.
 

--- a/async.js
+++ b/async.js
@@ -1,0 +1,17 @@
+var typeforce = require('./')
+
+// async wrapper
+function tfAsync (type, value, strict, callback) {
+  // default to falsy strict if using shorthand overload
+  if (typeof strict === 'function') return tfAsync(type, value, false, strict)
+
+  try {
+    typeforce(type, value, strict)
+  } catch (e) {
+    return callback(e)
+  }
+
+  callback()
+}
+
+module.exports = Object.assign(tfAsync, typeforce)

--- a/index.js
+++ b/index.js
@@ -230,21 +230,6 @@ for (typeName in EXTRA) {
   typeforce[typeName] = EXTRA[typeName]
 }
 
-// async wrapper
-function __async (type, value, strict, callback) {
-  // default to falsy strict if using shorthand overload
-  if (typeof strict === 'function') return __async(type, value, false, strict)
-
-  try {
-    typeforce(type, value, strict)
-  } catch (e) {
-    return callback(e)
-  }
-
-  callback()
-}
-
-typeforce.async = __async
 typeforce.compile = compile
 typeforce.TfTypeError = TfTypeError
 typeforce.TfPropertyTypeError = TfPropertyTypeError

--- a/nothrow.js
+++ b/nothrow.js
@@ -1,0 +1,12 @@
+var typeforce = require('./')
+
+function tfNoThrow (type, value, strict) {
+  try {
+    return typeforce(type, value, strict)
+  } catch (e) {
+    tfNoThrow.error = e
+    return false
+  }
+}
+
+module.exports = Object.assign(tfNoThrow, typeforce)

--- a/package.json
+++ b/package.json
@@ -18,10 +18,12 @@
   "author": "Daniel Cousens",
   "main": "index.js",
   "files": [
+    "async.js",
     "errors.js",
     "extra.js",
     "index.js",
-    "native.js"
+    "native.js",
+    "nothrow.js"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Adds `require('typeforce/async')`
- Adds `require('typeforce/nothrow')`